### PR TITLE
Fix MCTS policy handling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Alle Komponenten sind in **Python 3 + PyTorch 2.2 (CUDA 12.8)** gehalten und lau
 
 ## 3. Projektstruktur
 
-````
+```
 
 chess-selfplay-rl/
 ├─ README.md          ← diese Datei
@@ -56,7 +56,7 @@ chess-selfplay-rl/
 ├─ selfplay/…      ← .pt-Dateien (Bretter, Policy, Value)
 └─ checkpoints/    ← gespeicherte Netze
 
-````
+```
 
 ---
 
@@ -66,7 +66,7 @@ chess-selfplay-rl/
 2. **Skelett-Netz initialisieren**  
    ```bash
    python -m chess_zero.model --init checkpoints/000.pt
-````
+```
 
 3. **Erste 100 Selbstpartien erzeugen**
 

--- a/src/chess_zero/evaluate.py
+++ b/src/chess_zero/evaluate.py
@@ -36,6 +36,7 @@ def main():
     args = parser.parse_args()
     if args.uci:
         print('UCI mode not yet implemented')
+        return
     else:
         res = play_against_stockfish(args.engine, 'stockfish')
         print(res)

--- a/src/chess_zero/mcts.py
+++ b/src/chess_zero/mcts.py
@@ -63,10 +63,11 @@ class MCTS:
         return root
 
     def _expand(self, node: Node):
-        for move in node.board.legal_moves:
+        moves = list(node.board.legal_moves)
+        for move in moves:
             new_board = node.board.copy()
             new_board.push(move)
-            node.children[move] = Node(new_board, parent=node, prior=1/len(list(node.board.legal_moves)))
+            node.children[move] = Node(new_board, parent=node, prior=1 / len(moves))
 
     def _evaluate(self, node: Node):
         tensor = board_to_tensor(node.board).unsqueeze(0)
@@ -74,7 +75,8 @@ class MCTS:
             policy, value = self.model(tensor)
         # simple prior distribution over legal moves
         policy = torch.softmax(policy[0], dim=0)
-        for move, p in zip(node.board.legal_moves, policy[: node.board.legal_moves.count()]):
+        moves = list(node.board.legal_moves)
+        for move, p in zip(moves, policy[: len(moves)]):
             if move in node.children:
                 node.children[move].prior = p.item()
         return value.item()

--- a/src/chess_zero/utils.py
+++ b/src/chess_zero/utils.py
@@ -22,7 +22,9 @@ def board_to_tensor(board: chess.Board) -> torch.Tensor:
         if piece:
             color_offset = 0 if piece.color == chess.WHITE else 6
             index = PIECE_TO_INDEX[piece.piece_type] + color_offset
-            planes[index, square // 8, square % 8] = 1.0
+            row = 7 - square // 8
+            col = square % 8
+            planes[index, row, col] = 1.0
 
     # Aux planes
     planes[12].fill_(1.0 if board.turn == chess.WHITE else 0.0)
@@ -30,6 +32,6 @@ def board_to_tensor(board: chess.Board) -> torch.Tensor:
     planes[14].fill_(1.0 if board.has_queenside_castling_rights(chess.WHITE) else 0.0)
     planes[15].fill_(1.0 if board.has_kingside_castling_rights(chess.BLACK) else 0.0)
     planes[16].fill_(1.0 if board.has_queenside_castling_rights(chess.BLACK) else 0.0)
-    planes[17].fill_(board.fullmove_number)
+    planes[17].fill_(min(board.fullmove_number / 200, 1.0))
 
     return planes


### PR DESCRIPTION
## Summary
- normalize move counts when expanding nodes
- handle policy logits using explicit move list
- orient tensor rows from a8 at the top and normalize move counter
- add early return for unsupported UCI mode
- clean up Markdown fences in README

## Testing
- `python -m py_compile src/chess_zero/mcts.py src/chess_zero/utils.py src/chess_zero/evaluate.py`

------
https://chatgpt.com/codex/tasks/task_e_687cf84c626c8325bd28fb87a13381cb